### PR TITLE
Allow configuring channels via API

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,7 @@ pip install -r requirements.txt
 Configure as variáveis de ambiente:
 
 - `TELEGRAM_BOT_TOKEN`: token do bot.
-- `PUBLIC_CHANNEL_ID`: id do canal público.
-- `PRIVATE_CHANNEL_ID`: id do canal privado.
+- Os canais público e privado são configurados pela API.
 - `MERCADO_PAGO_TOKEN`: token do Mercado Pago (opcional).
 - `CRON_HOUR`: horário (0-23) para os posts agendados (padrão 9).
 
@@ -39,6 +38,9 @@ A API fornece os seguintes endpoints:
 - `POST /posts/public` — adiciona um post público.
 - `POST /posts/private` — adiciona um post privado.
 - `GET /stats` — exibe estatísticas de usuários e assinaturas.
+- `GET /channels/available` — lista canais que o bot possui acesso.
+- `GET /channels/config` — obtém os canais configurados.
+- `POST /channels/config` — define o canal público e o privado.
 
 ## Funções Principais
 
@@ -71,7 +73,7 @@ A API fornece os seguintes endpoints:
 
 ### `bot/database.py`
 
-Contém os modelos SQLAlchemy (`User`, `PublicPost`, `PrivatePost`) e a função `get_session()` para obter uma sessão do banco.
+Contém os modelos SQLAlchemy (`User`, `PublicPost`, `PrivatePost`, `BotConfig`) e a função `get_session()` para obter uma sessão do banco.
 
 ## Executando testes
 

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -1,7 +1,6 @@
 from telegram.ext import Updater, CommandHandler
-from telegram import ParseMode
 
-from .config import BOT_TOKEN, PRIVATE_CHANNEL_ID
+from .config import BOT_TOKEN
 from .subscriptions import create_user
 from .subscriptions import MONTHLY_PRICE, LIFETIME_PRICE
 from .payments import create_payment

--- a/bot/config.py
+++ b/bot/config.py
@@ -1,9 +1,27 @@
 import os
 
 BOT_TOKEN = os.getenv('TELEGRAM_BOT_TOKEN')
-PUBLIC_CHANNEL_ID = int(os.getenv('PUBLIC_CHANNEL_ID', '0'))
-PRIVATE_CHANNEL_ID = int(os.getenv('PRIVATE_CHANNEL_ID', '0'))
 MERCADO_PAGO_TOKEN = os.getenv('MERCADO_PAGO_TOKEN')
 
 # Default cron hour for daily posts
 CRON_HOUR = int(os.getenv('CRON_HOUR', '9'))  # 9 AM
+
+from .database import get_session, get_bot_config
+
+
+def get_public_channel_id() -> int | None:
+    session = get_session()
+    return get_bot_config(session).public_channel_id
+
+
+def get_private_channel_id() -> int | None:
+    session = get_session()
+    return get_bot_config(session).private_channel_id
+
+
+def set_channels(public_id: int, private_id: int) -> None:
+    session = get_session()
+    config = get_bot_config(session)
+    config.public_channel_id = public_id
+    config.private_channel_id = private_id
+    session.commit()

--- a/bot/database.py
+++ b/bot/database.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta
 from sqlalchemy import create_engine, Column, Integer, String, Boolean, DateTime
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import sessionmaker, Session
 
 engine = create_engine('sqlite:///bot.db')
 SessionLocal = sessionmaker(bind=engine)
@@ -28,7 +28,23 @@ class PrivatePost(Base):
     text = Column(String)
     images = Column(String)
 
+
+class BotConfig(Base):
+    __tablename__ = 'bot_config'
+    id = Column(Integer, primary_key=True)
+    public_channel_id = Column(Integer, nullable=True)
+    private_channel_id = Column(Integer, nullable=True)
+
 Base.metadata.create_all(engine)
 
 def get_session():
     return SessionLocal()
+
+
+def get_bot_config(session: Session) -> BotConfig:
+    config = session.query(BotConfig).first()
+    if not config:
+        config = BotConfig(id=1)
+        session.add(config)
+        session.commit()
+    return config

--- a/bot/poster.py
+++ b/bot/poster.py
@@ -1,11 +1,13 @@
-from datetime import datetime
-from pathlib import Path
 from typing import List
 from telegram import Bot, InputMediaPhoto
 from sqlalchemy.orm import Session
 
-from .config import BOT_TOKEN, PUBLIC_CHANNEL_ID, PRIVATE_CHANNEL_ID
-from .database import PublicPost, PrivatePost, get_session
+from .config import (
+    BOT_TOKEN,
+    get_public_channel_id,
+    get_private_channel_id,
+)
+from .database import PublicPost, PrivatePost
 
 bot = Bot(BOT_TOKEN)
 
@@ -23,7 +25,9 @@ def send_public_post(session: Session):
     if not post:
         return
     images = [img.strip() for img in (post.images or '').split(',') if img.strip()]
-    _send_images(PUBLIC_CHANNEL_ID, post.text, images)
+    channel_id = get_public_channel_id()
+    if channel_id:
+        _send_images(channel_id, post.text, images)
     session.delete(post)
     session.commit()
 
@@ -33,6 +37,8 @@ def send_private_post(session: Session):
     if not post:
         return
     images = [img.strip() for img in (post.images or '').split(',') if img.strip()]
-    _send_images(PRIVATE_CHANNEL_ID, post.text, images)
+    channel_id = get_private_channel_id()
+    if channel_id:
+        _send_images(channel_id, post.text, images)
     session.delete(post)
     session.commit()


### PR DESCRIPTION
## Summary
- store public and private channel IDs in database
- expose API endpoints to list available channels and configure them
- load channel IDs from database when sending posts
- document new configuration flow

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687d4dfaaeb0832e934e1c8adc8f4161