### PR TITLE
Fix APScheduler timezone bug

### DIFF
--- a/bot/scheduler.py
+++ b/bot/scheduler.py
@@ -1,15 +1,16 @@
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.cron import CronTrigger
+import pytz
 
 from .database import get_session
 from .poster import send_public_post, send_private_post
 from .config import CRON_HOUR
 
-scheduler = BackgroundScheduler()
+scheduler = BackgroundScheduler(timezone=pytz.utc)
 
 
 def start():
-    trigger = CronTrigger(hour=CRON_HOUR, minute=0)
+    trigger = CronTrigger(hour=CRON_HOUR, minute=0, timezone=pytz.utc)
     scheduler.add_job(lambda: send_public_post(get_session()), trigger)
     scheduler.add_job(lambda: send_private_post(get_session()), trigger)
     scheduler.start()

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ fastapi==0.110.0
 uvicorn==0.29.0
 mercadopago==2.3.0
 pydantic==2.7.1
+pytz==2024.1


### PR DESCRIPTION
## Summary
- use `pytz` timezones in `bot/scheduler.py` to avoid `zoneinfo` errors
- add `pytz` dependency

## Testing
- `python3 -m compileall -q bot web main.py`

------
https://chatgpt.com/codex/tasks/task_e_687d54f9b130832e8fd1a73316b641ad