### PR TITLE
Improve config loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,16 @@ Este projeto possui um bot do Telegram com opções de assinatura e um servidor 
 pip install -r requirements.txt
 ```
 
-Configure as variáveis de ambiente:
+As variáveis podem ser definidas no ambiente ou em um arquivo `.env` na raiz do
+projeto com o seguinte formato:
+
+```
+TELEGRAM_BOT_TOKEN=seu_token
+MERCADO_PAGO_TOKEN=opcional
+CRON_HOUR=9
+```
+
+Essas variáveis são:
 
 - `TELEGRAM_BOT_TOKEN`: token do bot.
 - Os canais público e privado são configurados pela API.

--- a/bot/config.py
+++ b/bot/config.py
@@ -1,6 +1,12 @@
 import os
+from dotenv import load_dotenv
+
+# Load environment variables from a .env file if present
+load_dotenv()
 
 BOT_TOKEN = os.getenv('TELEGRAM_BOT_TOKEN')
+if not BOT_TOKEN:
+    raise RuntimeError('TELEGRAM_BOT_TOKEN environment variable not set')
 MERCADO_PAGO_TOKEN = os.getenv('MERCADO_PAGO_TOKEN')
 
 # Default cron hour for daily posts

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ uvicorn==0.29.0
 mercadopago==2.3.0
 pydantic==2.7.1
 pytz==2024.1
+python-dotenv==1.0.1


### PR DESCRIPTION
## Summary
- load environment variables from `.env`
- document `.env` usage in README
- add `python-dotenv` dependency

## Testing
- `python -m py_compile main.py bot/*.py web/*.py`
- `pip install -q -r requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687d5619c708832e8a00af98ca4a5c68