### PR TITLE
Improve web dashboard with styling and multiple pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,23 @@ A API fornece os seguintes endpoints:
 
 - `POST /posts/public` — adiciona um post público.
 - `POST /posts/private` — adiciona um post privado.
+- `GET /posts/public` — lista posts públicos agendados.
+- `GET /posts/private` — lista posts privados agendados.
 - `GET /stats` — exibe estatísticas de usuários e assinaturas.
 - `GET /channels/available` — lista canais que o bot possui acesso.
 - `GET /channels/config` — obtém os canais configurados.
 - `POST /channels/config` — define o canal público e o privado.
+
+### Interface Web
+
+A pasta `web/static` contém páginas HTML simples para gerenciamento do bot.
+Elas podem ser acessadas após iniciar a API:
+
+- `index.html` — página inicial com links.
+- `private_posts.html` — lista e cria posts para o canal privado.
+- `public_posts.html` — lista e cria posts para o canal público.
+- `channels.html` — configuração dos canais.
+- `stats.html` — painel de estatísticas.
 
 ## Funções Principais
 

--- a/web/app.py
+++ b/web/app.py
@@ -3,7 +3,13 @@ from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 
-from bot.database import get_session, User, PublicPost, PrivatePost, get_bot_config
+from bot.database import (
+    get_session,
+    User,
+    PublicPost,
+    PrivatePost,
+    get_bot_config,
+)
 from bot.poster import bot as telegram_bot
 from bot.config import set_channels
 
@@ -35,6 +41,17 @@ def add_public_post(post: PostIn):
     return {'status': 'ok'}
 
 
+@app.get('/posts/public')
+def list_public_posts():
+    session = get_session()
+    posts = session.query(PublicPost).order_by(PublicPost.id).all()
+    data = [
+        {'id': p.id, 'text': p.text, 'images': p.images}
+        for p in posts
+    ]
+    return {'posts': data}
+
+
 @app.post('/posts/private')
 def add_private_post(post: PostIn):
     session = get_session()
@@ -42,6 +59,17 @@ def add_private_post(post: PostIn):
     session.add(obj)
     session.commit()
     return {'status': 'ok'}
+
+
+@app.get('/posts/private')
+def list_private_posts():
+    session = get_session()
+    posts = session.query(PrivatePost).order_by(PrivatePost.id).all()
+    data = [
+        {'id': p.id, 'text': p.text, 'images': p.images}
+        for p in posts
+    ]
+    return {'posts': data}
 
 
 @app.get('/stats')

--- a/web/static/channels.html
+++ b/web/static/channels.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <title>Configurar Canais</title>
+    <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+<nav>
+    <a href="/static/index.html">Início</a>
+    <a href="/static/private_posts.html">Posts Privados</a>
+    <a href="/static/public_posts.html">Posts Públicos</a>
+    <a href="/static/stats.html">Estatísticas</a>
+</nav>
+<h2>Configurar Canais</h2>
+<button onclick="loadChannels()">Carregar Configuração Atual</button>
+<pre id="current-channels"></pre>
+<input id="public-channel" type="text" placeholder="ID canal público">
+<input id="private-channel" type="text" placeholder="ID canal privado">
+<button onclick="saveChannels()">Salvar</button>
+<script>
+async function loadChannels() {
+    const res = await fetch('/channels/config');
+    const data = await res.json();
+    document.getElementById('current-channels').textContent = JSON.stringify(data, null, 2);
+    document.getElementById('public-channel').value = data.public_channel_id || '';
+    document.getElementById('private-channel').value = data.private_channel_id || '';
+}
+async function saveChannels() {
+    const body = {
+        public_channel_id: parseInt(document.getElementById('public-channel').value),
+        private_channel_id: parseInt(document.getElementById('private-channel').value)
+    };
+    const res = await fetch('/channels/config', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify(body)
+    });
+    if(res.ok) alert('Salvo com sucesso');
+    else alert('Erro ao salvar');
+}
+loadChannels();
+</script>
+</body>
+</html>

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -3,114 +3,15 @@
 <head>
     <meta charset="UTF-8">
     <title>Painel do Bot</title>
-    <style>
-        body { font-family: Arial, sans-serif; margin: 20px; }
-        section { margin-bottom: 2em; }
-        textarea { width: 100%; height: 60px; }
-        input[type=text] { width: 100%; }
-    </style>
+    <link rel="stylesheet" href="/static/style.css">
 </head>
 <body>
 <h1>Painel do Bot</h1>
-
-<section>
-    <h2>Adicionar Post Público</h2>
-    <textarea id="public-text" placeholder="Texto"></textarea><br>
-    <input id="public-images" type="text" placeholder="imagem1.jpg, imagem2.jpg"><br>
-    <button onclick="addPublicPost()">Enviar</button>
-</section>
-
-<section>
-    <h2>Adicionar Post Privado</h2>
-    <textarea id="private-text" placeholder="Texto"></textarea><br>
-    <input id="private-images" type="text" placeholder="imagem1.jpg, imagem2.jpg"><br>
-    <button onclick="addPrivatePost()">Enviar</button>
-</section>
-
-<section>
-    <h2>Configurar Canais</h2>
-    <button onclick="loadChannelsConfig()">Carregar Configuração Atual</button><br>
-    <pre id="current-channels"></pre>
-    <input id="public-channel" type="text" placeholder="ID canal público"><br>
-    <input id="private-channel" type="text" placeholder="ID canal privado"><br>
-    <button onclick="setChannels()">Salvar</button>
-</section>
-
-<section>
-    <h2>Canais Disponíveis</h2>
-    <button onclick="loadAvailableChannels()">Listar</button>
-    <ul id="available-channels"></ul>
-</section>
-
-<section>
-    <h2>Estatísticas</h2>
-    <button onclick="loadStats()">Atualizar</button>
-    <pre id="stats"></pre>
-</section>
-
-<script>
-async function addPublicPost() {
-    const body = {
-        text: document.getElementById('public-text').value,
-        images: document.getElementById('public-images').value
-    };
-    const res = await fetch('/posts/public', {
-        method: 'POST',
-        headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify(body)
-    });
-    alert('Status: ' + res.status);
-}
-
-async function addPrivatePost() {
-    const body = {
-        text: document.getElementById('private-text').value,
-        images: document.getElementById('private-images').value
-    };
-    const res = await fetch('/posts/private', {
-        method: 'POST',
-        headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify(body)
-    });
-    alert('Status: ' + res.status);
-}
-
-async function loadChannelsConfig() {
-    const res = await fetch('/channels/config');
-    const data = await res.json();
-    document.getElementById('current-channels').textContent = JSON.stringify(data, null, 2);
-}
-
-async function setChannels() {
-    const body = {
-        public_channel_id: parseInt(document.getElementById('public-channel').value),
-        private_channel_id: parseInt(document.getElementById('private-channel').value)
-    };
-    const res = await fetch('/channels/config', {
-        method: 'POST',
-        headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify(body)
-    });
-    alert('Status: ' + res.status);
-}
-
-async function loadAvailableChannels() {
-    const res = await fetch('/channels/available');
-    const data = await res.json();
-    const ul = document.getElementById('available-channels');
-    ul.innerHTML = '';
-    for (const ch of data.channels) {
-        const li = document.createElement('li');
-        li.textContent = ch.id + ' - ' + ch.title;
-        ul.appendChild(li);
-    }
-}
-
-async function loadStats() {
-    const res = await fetch('/stats');
-    const data = await res.json();
-    document.getElementById('stats').textContent = JSON.stringify(data, null, 2);
-}
-</script>
+<nav>
+    <a href="/static/private_posts.html">Posts Privados</a>
+    <a href="/static/public_posts.html">Posts Públicos</a>
+    <a href="/static/channels.html">Configuração de Canais</a>
+    <a href="/static/stats.html">Estatísticas</a>
+</nav>
 </body>
 </html>

--- a/web/static/private_posts.html
+++ b/web/static/private_posts.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <title>Posts Privados</title>
+    <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+<nav>
+    <a href="/static/index.html">Início</a>
+    <a href="/static/public_posts.html">Posts Públicos</a>
+    <a href="/static/channels.html">Configuração de Canais</a>
+    <a href="/static/stats.html">Estatísticas</a>
+</nav>
+<h2>Posts Agendados (Privado)</h2>
+<ul id="private-posts"></ul>
+<h3>Novo Post</h3>
+<textarea id="private-text" placeholder="Texto"></textarea>
+<input id="private-images" type="text" placeholder="imagem1.jpg, imagem2.jpg">
+<button onclick="addPrivatePost()">Enviar</button>
+<script>
+async function loadPrivatePosts() {
+    const res = await fetch('/posts/private');
+    const data = await res.json();
+    const ul = document.getElementById('private-posts');
+    ul.innerHTML = '';
+    for (const p of data.posts) {
+        const li = document.createElement('li');
+        li.className = 'list';
+        li.textContent = p.text + (p.images ? ' [' + p.images + ']' : '');
+        ul.appendChild(li);
+    }
+}
+async function addPrivatePost() {
+    const body = {
+        text: document.getElementById('private-text').value,
+        images: document.getElementById('private-images').value
+    };
+    const res = await fetch('/posts/private', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify(body)
+    });
+    if (res.ok) {
+        document.getElementById('private-text').value = '';
+        document.getElementById('private-images').value = '';
+        loadPrivatePosts();
+    } else {
+        alert('Erro ao enviar');
+    }
+}
+loadPrivatePosts();
+</script>
+</body>
+</html>

--- a/web/static/public_posts.html
+++ b/web/static/public_posts.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <title>Posts Públicos</title>
+    <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+<nav>
+    <a href="/static/index.html">Início</a>
+    <a href="/static/private_posts.html">Posts Privados</a>
+    <a href="/static/channels.html">Configuração de Canais</a>
+    <a href="/static/stats.html">Estatísticas</a>
+</nav>
+<h2>Posts Agendados (Público)</h2>
+<ul id="public-posts"></ul>
+<h3>Novo Post</h3>
+<textarea id="public-text" placeholder="Texto"></textarea>
+<input id="public-images" type="text" placeholder="imagem1.jpg, imagem2.jpg">
+<button onclick="addPublicPost()">Enviar</button>
+<script>
+async function loadPublicPosts() {
+    const res = await fetch('/posts/public');
+    const data = await res.json();
+    const ul = document.getElementById('public-posts');
+    ul.innerHTML = '';
+    for (const p of data.posts) {
+        const li = document.createElement('li');
+        li.className = 'list';
+        li.textContent = p.text + (p.images ? ' [' + p.images + ']' : '');
+        ul.appendChild(li);
+    }
+}
+async function addPublicPost() {
+    const body = {
+        text: document.getElementById('public-text').value,
+        images: document.getElementById('public-images').value
+    };
+    const res = await fetch('/posts/public', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify(body)
+    });
+    if (res.ok) {
+        document.getElementById('public-text').value = '';
+        document.getElementById('public-images').value = '';
+        loadPublicPosts();
+    } else {
+        alert('Erro ao enviar');
+    }
+}
+loadPublicPosts();
+</script>
+</body>
+</html>

--- a/web/static/stats.html
+++ b/web/static/stats.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <title>Estatísticas</title>
+    <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+<nav>
+    <a href="/static/index.html">Início</a>
+    <a href="/static/private_posts.html">Posts Privados</a>
+    <a href="/static/public_posts.html">Posts Públicos</a>
+    <a href="/static/channels.html">Configuração de Canais</a>
+</nav>
+<h2>Estatísticas</h2>
+<div id="stats" class="stats-grid"></div>
+<script>
+async function loadStats() {
+    const res = await fetch('/stats');
+    const data = await res.json();
+    const grid = document.getElementById('stats');
+    grid.innerHTML = '';
+    const items = [
+        {label: 'Usuários Públicos', value: data.usuarios_publicos},
+        {label: 'Usuários Privados', value: data.usuarios_privados},
+        {label: 'Assinaturas Mensais', value: data.assinaturas_mensais},
+        {label: 'Assinaturas Vitalícias', value: data.assinaturas_vitalicias},
+    ];
+    for (const it of items) {
+        const card = document.createElement('div');
+        card.className = 'card';
+        card.innerHTML = `<h3>${it.label}</h3><p>${it.value}</p>`;
+        grid.appendChild(card);
+    }
+}
+loadStats();
+</script>
+</body>
+</html>

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -1,0 +1,47 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 20px;
+    max-width: 800px;
+}
+nav {
+    margin-bottom: 20px;
+}
+nav a {
+    margin-right: 10px;
+    padding: 8px 12px;
+    background: #eee;
+    border-radius: 4px;
+    text-decoration: none;
+    color: #333;
+}
+section {
+    margin-bottom: 1.5em;
+}
+textarea, input[type=text] {
+    width: 100%;
+    padding: 6px;
+    margin-top: 4px;
+}
+button {
+    padding: 8px 12px;
+    margin-top: 6px;
+}
+.list {
+    border: 1px solid #ccc;
+    padding: 10px;
+    border-radius: 4px;
+    margin-bottom: 10px;
+}
+.stats-grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 20px;
+}
+.card {
+    background: #f5f5f5;
+    padding: 20px;
+    border-radius: 8px;
+    flex: 1 0 200px;
+    text-align: center;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}


### PR DESCRIPTION
## Summary
- add GET endpoints for listing posts
- split HTML into multiple pages and add navigation
- create a shared CSS file with basic styling
- add a stats dashboard and channel configuration pages
- document new endpoints and web UI in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687d5878a9f0832e99420f5bfeffabef