### PR TITLE
Handle Telegram API timeouts

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -10,6 +10,7 @@ from bot.database import (
     PrivatePost,
     get_bot_config,
 )
+from telegram.error import TimedOut, NetworkError
 from bot.poster import bot as telegram_bot
 from bot.config import set_channels
 
@@ -110,7 +111,10 @@ def set_channels_endpoint(cfg: ChannelConfigIn):
 
 @app.get('/channels/available')
 def list_channels():
-    updates = telegram_bot.get_updates()
+    try:
+        updates = telegram_bot.get_updates()
+    except (TimedOut, NetworkError):
+        updates = []
     channels = {}
     for u in updates:
         chat = None


### PR DESCRIPTION
## Summary
- catch telegram errors in `list_channels`
- add imports for timeout handling

## Testing
- `python3 -m py_compile web/app.py`


------
https://chatgpt.com/codex/tasks/task_e_687d5e14fa40832e94b9b01787d3eccd