### PR TITLE
Add migration routine for SQLite

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,9 @@
 
 from bot.scheduler import start as start_scheduler
 from bot.bot import start_bot
+from bot.database import migrate
 
 if __name__ == '__main__':
+    migrate()
     start_scheduler()
     start_bot()

--- a/web/app.py
+++ b/web/app.py
@@ -11,10 +11,13 @@ from bot.database import (
     PublicPost,
     PrivatePost,
     get_bot_config,
+    migrate,
 )
 from telegram.error import TimedOut, NetworkError
 from bot.poster import bot as telegram_bot
 from bot.config import set_channels
+
+migrate()
 
 app = FastAPI()
 app.mount('/static', StaticFiles(directory='web/static'), name='static')


### PR DESCRIPTION
## Summary
- implement simple migration in `bot/database.py` to add missing tables or columns
- call migration when starting the bot (`main.py`)
- call migration when loading the FastAPI app (`web/app.py`)

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687d63d0b7bc832eb6e7acab08f30d94