### PR TITLE
Add manual send endpoints and buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ A API fornece os seguintes endpoints:
 - `POST /posts/private` — adiciona um post privado (campo `text` e múltiplos arquivos `files`).
 - `GET /posts/public` — lista posts públicos agendados.
 - `GET /posts/private` — lista posts privados agendados.
+- `POST /posts/public/{id}/send` — envia imediatamente o post público indicado.
+- `POST /posts/private/{id}/send` — envia imediatamente o post privado indicado.
 - `GET /stats` — exibe estatísticas de usuários e assinaturas.
 - `GET /channels/available` — lista canais que o bot possui acesso.
 - `GET /channels/config` — obtém os canais configurados.

--- a/bot/poster.py
+++ b/bot/poster.py
@@ -25,13 +25,16 @@ def _send_media(chat_id: int, text: str, files: List[str]):
         bot.send_message(chat_id=chat_id, text=text)
 
 
-def send_public_post(session: Session):
-    post = (
-        session.query(PublicPost)
-        .filter_by(sent=False)
-        .order_by(PublicPost.id)
-        .first()
-    )
+def send_public_post(session: Session, post_id: int | None = None):
+    if post_id is not None:
+        post = session.query(PublicPost).filter_by(id=post_id, sent=False).first()
+    else:
+        post = (
+            session.query(PublicPost)
+            .filter_by(sent=False)
+            .order_by(PublicPost.id)
+            .first()
+        )
     if not post:
         return
     images = [img.strip() for img in (post.images or '').split(',') if img.strip()]
@@ -42,13 +45,16 @@ def send_public_post(session: Session):
     session.commit()
 
 
-def send_private_post(session: Session):
-    post = (
-        session.query(PrivatePost)
-        .filter_by(sent=False)
-        .order_by(PrivatePost.id)
-        .first()
-    )
+def send_private_post(session: Session, post_id: int | None = None):
+    if post_id is not None:
+        post = session.query(PrivatePost).filter_by(id=post_id, sent=False).first()
+    else:
+        post = (
+            session.query(PrivatePost)
+            .filter_by(sent=False)
+            .order_by(PrivatePost.id)
+            .first()
+        )
     if not post:
         return
     images = [img.strip() for img in (post.images or '').split(',') if img.strip()]

--- a/web/static/private_posts.html
+++ b/web/static/private_posts.html
@@ -28,6 +28,12 @@ async function loadPrivatePosts() {
         const li = document.createElement('li');
         li.className = 'list';
         li.innerHTML = `<strong>${p.sent ? 'Enviado' : 'Pendente'}</strong><p>${p.text}</p>`;
+        if (!p.sent) {
+            const btn = document.createElement('button');
+            btn.textContent = 'Enviar Agora';
+            btn.onclick = () => sendPrivatePost(p.id);
+            li.appendChild(btn);
+        }
         if (p.images) {
             const files = p.images.split(',').map(s => s.trim()).filter(s => s);
             for (const f of files) {
@@ -64,6 +70,15 @@ async function addPrivatePost() {
     if (res.ok) {
         document.getElementById('private-text').value = '';
         document.getElementById('private-files').value = '';
+        loadPrivatePosts();
+    } else {
+        alert('Erro ao enviar');
+    }
+}
+
+async function sendPrivatePost(id) {
+    const res = await fetch(`/posts/private/${id}/send`, { method: 'POST' });
+    if (res.ok) {
         loadPrivatePosts();
     } else {
         alert('Erro ao enviar');

--- a/web/static/public_posts.html
+++ b/web/static/public_posts.html
@@ -28,6 +28,12 @@ async function loadPublicPosts() {
         const li = document.createElement('li');
         li.className = 'list';
         li.innerHTML = `<strong>${p.sent ? 'Enviado' : 'Pendente'}</strong><p>${p.text}</p>`;
+        if (!p.sent) {
+            const btn = document.createElement('button');
+            btn.textContent = 'Enviar Agora';
+            btn.onclick = () => sendPublicPost(p.id);
+            li.appendChild(btn);
+        }
         if (p.images) {
             const files = p.images.split(',').map(s => s.trim()).filter(s => s);
             for (const f of files) {
@@ -64,6 +70,15 @@ async function addPublicPost() {
     if (res.ok) {
         document.getElementById('public-text').value = '';
         document.getElementById('public-files').value = '';
+        loadPublicPosts();
+    } else {
+        alert('Erro ao enviar');
+    }
+}
+
+async function sendPublicPost(id) {
+    const res = await fetch(`/posts/public/${id}/send`, { method: 'POST' });
+    if (res.ok) {
         loadPublicPosts();
     } else {
         alert('Erro ao enviar');


### PR DESCRIPTION
## Summary
- allow sending a specific post immediately
- show **Enviar Agora** buttons in public/private lists
- provide APIs to trigger sending and update README
- update poster functions to accept optional post id

## Testing
- `python3 -B -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687d65691cf4832ebe13f1fe6cb266d8