### PR TITLE
Enable manual repost of sent items

### DIFF
--- a/bot/poster.py
+++ b/bot/poster.py
@@ -25,9 +25,12 @@ def _send_media(chat_id: int, text: str, files: List[str]):
         bot.send_message(chat_id=chat_id, text=text)
 
 
-def send_public_post(session: Session, post_id: int | None = None):
+def send_public_post(session: Session, post_id: int | None = None, resend: bool = False):
     if post_id is not None:
-        post = session.query(PublicPost).filter_by(id=post_id, sent=False).first()
+        if resend:
+            post = session.query(PublicPost).filter_by(id=post_id).first()
+        else:
+            post = session.query(PublicPost).filter_by(id=post_id, sent=False).first()
     else:
         post = (
             session.query(PublicPost)
@@ -45,9 +48,12 @@ def send_public_post(session: Session, post_id: int | None = None):
     session.commit()
 
 
-def send_private_post(session: Session, post_id: int | None = None):
+def send_private_post(session: Session, post_id: int | None = None, resend: bool = False):
     if post_id is not None:
-        post = session.query(PrivatePost).filter_by(id=post_id, sent=False).first()
+        if resend:
+            post = session.query(PrivatePost).filter_by(id=post_id).first()
+        else:
+            post = session.query(PrivatePost).filter_by(id=post_id, sent=False).first()
     else:
         post = (
             session.query(PrivatePost)

--- a/web/app.py
+++ b/web/app.py
@@ -64,14 +64,14 @@ def list_public_posts():
 
 
 @app.post('/posts/public/{post_id}/send')
-def send_public_post_endpoint(post_id: int):
+def send_public_post_endpoint(post_id: int, resend: bool = False):
     session = get_session()
     post = session.query(PublicPost).filter_by(id=post_id).first()
     if not post:
         raise HTTPException(status_code=404, detail='Post não encontrado')
-    if post.sent:
+    if post.sent and not resend:
         raise HTTPException(status_code=400, detail='Post já enviado')
-    send_public_post(session, post_id=post_id)
+    send_public_post(session, post_id=post_id, resend=resend)
     return {'status': 'ok'}
 
 
@@ -103,14 +103,14 @@ def list_private_posts():
 
 
 @app.post('/posts/private/{post_id}/send')
-def send_private_post_endpoint(post_id: int):
+def send_private_post_endpoint(post_id: int, resend: bool = False):
     session = get_session()
     post = session.query(PrivatePost).filter_by(id=post_id).first()
     if not post:
         raise HTTPException(status_code=404, detail='Post não encontrado')
-    if post.sent:
+    if post.sent and not resend:
         raise HTTPException(status_code=400, detail='Post já enviado')
-    send_private_post(session, post_id=post_id)
+    send_private_post(session, post_id=post_id, resend=resend)
     return {'status': 'ok'}
 
 

--- a/web/static/private_posts.html
+++ b/web/static/private_posts.html
@@ -31,7 +31,16 @@ async function loadPrivatePosts() {
         if (!p.sent) {
             const btn = document.createElement('button');
             btn.textContent = 'Enviar Agora';
-            btn.onclick = () => sendPrivatePost(p.id);
+            btn.onclick = () => sendPrivatePost(p.id, false);
+            li.appendChild(btn);
+        } else {
+            const btn = document.createElement('button');
+            btn.textContent = 'Reenviar';
+            btn.onclick = () => {
+                if (confirm('Deseja reenviar este post?')) {
+                    sendPrivatePost(p.id, true);
+                }
+            };
             li.appendChild(btn);
         }
         if (p.images) {
@@ -76,8 +85,8 @@ async function addPrivatePost() {
     }
 }
 
-async function sendPrivatePost(id) {
-    const res = await fetch(`/posts/private/${id}/send`, { method: 'POST' });
+async function sendPrivatePost(id, resend) {
+    const res = await fetch(`/posts/private/${id}/send?resend=${resend}`, { method: 'POST' });
     if (res.ok) {
         loadPrivatePosts();
     } else {

--- a/web/static/public_posts.html
+++ b/web/static/public_posts.html
@@ -31,7 +31,16 @@ async function loadPublicPosts() {
         if (!p.sent) {
             const btn = document.createElement('button');
             btn.textContent = 'Enviar Agora';
-            btn.onclick = () => sendPublicPost(p.id);
+            btn.onclick = () => sendPublicPost(p.id, false);
+            li.appendChild(btn);
+        } else {
+            const btn = document.createElement('button');
+            btn.textContent = 'Reenviar';
+            btn.onclick = () => {
+                if (confirm('Deseja reenviar este post?')) {
+                    sendPublicPost(p.id, true);
+                }
+            };
             li.appendChild(btn);
         }
         if (p.images) {
@@ -76,8 +85,8 @@ async function addPublicPost() {
     }
 }
 
-async function sendPublicPost(id) {
-    const res = await fetch(`/posts/public/${id}/send`, { method: 'POST' });
+async function sendPublicPost(id, resend) {
+    const res = await fetch(`/posts/public/${id}/send?resend=${resend}`, { method: 'POST' });
     if (res.ok) {
         loadPublicPosts();
     } else {


### PR DESCRIPTION
## Summary
- allow posts to be sent again from the API
- show a "Reenviar" button for sent posts on the public and private pages
- confirm before resending

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687d66c44480832eb48561d981a0b83b